### PR TITLE
兼容统计vue和jsx文件圈复杂度

### DIFF
--- a/code-complexity/.eslintrc.js
+++ b/code-complexity/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+    extends: "eslint:recommended",
+    parser: "vue-eslint-parser"
+}

--- a/code-complexity/index.js
+++ b/code-complexity/index.js
@@ -11,6 +11,10 @@ const { CLIEngine } = eslint;
 const cli = new CLIEngine({
     parserOptions: {
         ecmaVersion: 2018,
+        sourceType: 'module',
+        ecmaFeatures: {
+            jsx: true
+        }
     },
     rules: {
         complexity: [
@@ -18,7 +22,7 @@ const cli = new CLIEngine({
             { max: 0 }
         ]
     },
-    useEslintrc: false
+    useEslintrc: true
 });
 
 /**

--- a/code-scan/index.js
+++ b/code-scan/index.js
@@ -1,43 +1,33 @@
-const path = require('path');
-const fs = require('fs');
-const glob = require('glob');
-const ignore = require('ignore');
-
-
+const path = require("path")
+const fs = require("fs")
+const glob = require("glob")
+const ignore = require("ignore")
 
 /**
  * 默认扫描扩展
  */
-const EXTENSIONS = '**/*.js';
+const EXTENSIONS = "**/*.?(js|vue|jsx)"
 
 /**
  * 默认忽略文件夹
  */
-const DEFAULT_IGNORE_PATTERNS = [
-    'node_modules/**',
-    'build/**',
-    'dist/**',
-    'output/**',
-    'common_build/**'
-];
+const DEFAULT_IGNORE_PATTERNS = ["node_modules/**", "build/**", "dist/**", "output/**", "common_build/**"]
 
 /**
  * ignore文件名
  */
-const IGNORE_FILE_NAME = '.gitignore';
-
+const IGNORE_FILE_NAME = ".gitignore"
 
 /**
  * 默认参数
  */
 const DEFAULT_PARAM = {
-    rootPath: '',
+    rootPath: "",
     ignoreRules: [],
     defalutIgnore: true,
     extensions: EXTENSIONS,
     ignoreFileName: IGNORE_FILE_NAME
-};
-
+}
 
 /**
  * 获取glob扫描的文件列表
@@ -47,66 +37,60 @@ const DEFAULT_PARAM = {
  */
 function getGlobScan(rootPath, extensions, defalutIgnore) {
     return new Promise(resolve => {
-        glob(`${rootPath}${extensions}`,
-            { dot: true, ignore: defalutIgnore ? DEFAULT_IGNORE_PATTERNS : [] },
-            (err, files) => {
-                if (err) {
-                    console.log(err);
-                    process.exit(1);
-                }
-                resolve(files);
-            });
-    });
+        glob(`${rootPath}${extensions}`, { dot: true, ignore: defalutIgnore ? DEFAULT_IGNORE_PATTERNS : [] }, (err, files) => {
+            if (err) {
+                console.log(err)
+                process.exit(1)
+            }
+            resolve(files)
+        })
+    })
 }
 
 /**
  * 加载ignore配置文件，并处理成数组
- * @param {*} ignoreFileName 
+ * @param {*} ignoreFileName
  */
 async function loadIgnorePatterns(ignoreFileName) {
-    const ignorePath = path.resolve(process.cwd(), ignoreFileName);
+    const ignorePath = path.resolve(process.cwd(), ignoreFileName)
     try {
-        const ignores = fs.readFileSync(ignorePath, 'utf8');
-        return ignores.split(/[\n\r]|\n\r/).filter(pattern => Boolean(pattern));
+        const ignores = fs.readFileSync(ignorePath, "utf8")
+        return ignores.split(/[\n\r]|\n\r/).filter(pattern => Boolean(pattern))
     } catch (e) {
-        return [];
+        return []
     }
 }
 
 /**
  * 根据ignore配置过滤文件列表
- * @param {*} files 
- * @param {*} ignorePatterns 
- * @param {*} cwd 
+ * @param {*} files
+ * @param {*} ignorePatterns
+ * @param {*} cwd
  */
 function filterFilesByIgnore(files, ignorePatterns, ignoreRules, cwd = process.cwd()) {
-    const ig = ignore().add([...ignorePatterns, ...ignoreRules]);
+    const ig = ignore().add([...ignorePatterns, ...ignoreRules])
     const filtered = files
         .map(raw => (path.isAbsolute(raw) ? raw : path.resolve(cwd, raw)))
         .map(raw => path.relative(cwd, raw))
         .filter(filePath => !ig.ignores(filePath))
-        .map(raw => path.resolve(cwd, raw));
-    return filtered;
+        .map(raw => path.resolve(cwd, raw))
+    return filtered
 }
-
 
 /**
  * 执行扫描
  * @param {*} path 扫描路径 - 默认为当前路径
  */
 module.exports = async function scan(param) {
+    param = Object.assign(DEFAULT_PARAM, param)
 
-    param = Object.assign(DEFAULT_PARAM, param);
+    const { rootPath, extensions, defalutIgnore, ignoreRules, ignoreFileName } = param
 
-    const { rootPath, extensions, defalutIgnore, ignoreRules, ignoreFileName } = param;
+    process.chdir(rootPath)
 
-    process.chdir(rootPath);
+    const ignorePatterns = await loadIgnorePatterns(ignoreFileName)
 
-    const ignorePatterns = await loadIgnorePatterns(ignoreFileName);
+    let files = await getGlobScan(rootPath, extensions, defalutIgnore)
 
-    let files = await getGlobScan(rootPath, extensions, defalutIgnore);
-
-    return filterFilesByIgnore(files, ignorePatterns, ignoreRules);
-
-};
-
+    return filterFilesByIgnore(files, ignorePatterns, ignoreRules)
+}


### PR DESCRIPTION
利用eslint-plugin-vue插件的vue-eslint-parser，可以让扫描到的vue文件 也能executeOnFiles，这样就可以分析vue文件的圈复杂度了，我自己试验过ok的。